### PR TITLE
Swgui should support submitted button for all http methods

### DIFF
--- a/index.tpl.go
+++ b/index.tpl.go
@@ -63,7 +63,6 @@ var indexTpl = `
       window.swaggerUi = new SwaggerUi({
         url: url,
         dom_id: "swagger-ui-container",
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
         onComplete: function(swaggerApi, swaggerUi){
           if(typeof initOAuth == "function") {
             initOAuth({


### PR DESCRIPTION
By default, swgui should supports the submitted button for all http methods

`swgui/static/swagger-ui.js:38`
```javascript
options.supportedSubmitMethods = [
        'get',
        'put',
        'post',
        'delete',
        'head',
        'options',
        'patch'
      ];
```